### PR TITLE
Remove leading zeroes in the date string when finding the date button

### DIFF
--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -135,7 +135,7 @@ class BrightonParking:
             date (datetime): date we want to select
         """
         # Get the matching string
-        date_string = date.strftime("%A, %B %d")
+        date_string = f'{date:%A}, {date:%B} {date.day}'
 
         # Find the date button
         btn = self.driver.find_element(

--- a/SolitudeParking.py
+++ b/SolitudeParking.py
@@ -21,7 +21,6 @@ class SolitudeParking:
         self.username = credentials['username']
         self.password = credentials['password']
 
-
     def start_session(self):
         """Creates the selenium session
         """
@@ -137,7 +136,7 @@ class SolitudeParking:
             date (datetime): date we want to select
         """
         # Get the matching string
-        date_string = date.strftime("%A, %B %d")
+        date_string = f'{date:%A}, {date:%B} {date.day}'
 
         # Find the date button
         btn = self.driver.find_element(
@@ -217,7 +216,7 @@ if __name__ == "__main__":
     # sp.go_to_selection_calendar()
     # sp.navigate_to_date(dt.datetime(2024, 2, 19))
     # sp.select_parking_option()
-    
+
 #     # sp.reserve()
 
 #     # just keep page open for debuggin


### PR DESCRIPTION
From solitude's website (I checked Brighton as well)

![image](https://github.com/kel89/parking-bot/assets/9903384/448a1c7a-3246-41ec-9c42-54cd318c3d53)

The aria labels do not have a leading zero for the day of the month, while strftime does, causing a bug when trying to reserve a date from the 1st to the 9th

This changes the date formatting to match.