### PR TITLE
Add scripts for polling reservations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ env/
 .DS_Store
 
 __pycache__/
+
+# polling config
+polling_config.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ env/
 .vscode/
 .env
 .DS_Store
+
+__pycache__/

--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -11,9 +11,6 @@ import time
 import os
 import datetime as dt
 
-from dotenv import load_dotenv
-
-load_dotenv()
 
 LOGIN_URL = "https://reservenski.parkbrightonresort.com/login"
 

--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -39,6 +39,11 @@ class BrightonParking:
         """Login the user with enviornment variables
         """
         # Get elements
+        # time.sleep(0)
+        WebDriverWait(self.driver, 15).until(EC.presence_of_all_elements_located(
+            (By.ID,
+             'emailAddress')
+        ))
         username = self.driver.find_element(By.ID, "emailAddress")
         password = self.driver.find_element(By.ID, "password")
         submit_btn = self.driver.find_element(
@@ -142,20 +147,23 @@ class BrightonParking:
         date_string = f'{date:%A}, {date:%B} {date.day}'
 
         # Find the date button
-        btn = self.driver.find_element(
+        btns = self.driver.find_elements(
             By.XPATH, '//div[@aria-label="{}"]'.format(date_string))
-        btn.click()
-
-        # Give it a moment to load the options
-        time.sleep(.5)
+        for btn in btns:
+            if btn.is_enabled() and btn.is_displayed():
+                btn.click()
+                break
 
     def select_parking_option(self):
         """Clicks the Season Pass Holder option once the date
         is selected, which redirect to purchasing
         """
-        # Find button
+        # Wait for button to load and click
+        btn_xpath = '//div[text()="Season\'s Pass"]/parent::*/parent::*'
+        WebDriverWait(self.driver, 3).until(EC.presence_of_element_located(
+            (By.XPATH, btn_xpath)))
         btn = self.driver.find_element(
-            By.XPATH, '//div[text()="Season\'s Pass"]/parent::*/parent::*')
+            By.XPATH, btn_xpath)
         btn.click()
 
         # Wait for honk to load
@@ -182,6 +190,8 @@ class BrightonParking:
         confirm_btn = self.driver.find_element(
             By.XPATH, '//button[text()="Confirm"]')
         confirm_btn.click()
+        # Give some time for the reservation to complete
+        time.sleep(3)
         print("Reservation complete")
 
     def output(self):
@@ -193,7 +203,8 @@ class BrightonParking:
         self.go_to_selection_calendar()
         self.navigate_to_date(target_date)
         self.select_parking_option()
-        self.reserve()
+        # self.reserve()
+        print("DONE")
 
 
 if __name__ == "__main__":
@@ -212,7 +223,7 @@ if __name__ == "__main__":
     sp.login()
     sp.activate_code()
     sp.go_to_selection_calendar()
-    sp.navigate_to_date(dt.datetime(2024, 1, 17))
+    sp.navigate_to_date(dt.datetime(2023, 12, 8))
     sp.select_parking_option()
     # sp.reserve()
     # Set a breakpoint here to keep page open

--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -205,7 +205,6 @@ class BrightonParking:
         self.navigate_to_date(target_date)
         self.select_parking_option()
         self.reserve()
-        print("DONE")
 
 
 if __name__ == "__main__":

--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -11,6 +11,10 @@ import time
 import os
 import datetime as dt
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 LOGIN_URL = "https://reservenski.parkbrightonresort.com/login"
 
 
@@ -201,14 +205,14 @@ if __name__ == "__main__":
     options.add_argument("--window-size=1280x1696")
     chrome = webdriver.Chrome(options=options)
     sp = BrightonParking(chrome, credentials={
-        'username': "amycai12@yahoo.com",
-        'password': "tiphes-mozki5-rArzun"
+        "username": os.getenv("USERNAME"),
+        "password": os.getenv("PASSWORD")
     })
     sp.start_session()
     sp.login()
     sp.activate_code()
     sp.go_to_selection_calendar()
-    sp.navigate_to_date(dt.datetime(2024, 1, 11))
+    sp.navigate_to_date(dt.datetime(2023, 12, 11))
     sp.select_parking_option()
     # sp.reserve()
     # Set a breakpoint here to keep page open

--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -139,7 +139,7 @@ class BrightonParking:
             date (datetime): date we want to select
         """
         # Get the matching string
-        date_string = date.strftime("%A, %B %d")
+        date_string = f'{date:%A}, {date:%B} {date.day}'
 
         # Find the date button
         btn = self.driver.find_element(
@@ -212,7 +212,7 @@ if __name__ == "__main__":
     sp.login()
     sp.activate_code()
     sp.go_to_selection_calendar()
-    sp.navigate_to_date(dt.datetime(2023, 12, 11))
+    sp.navigate_to_date(dt.datetime(2024, 1, 17))
     sp.select_parking_option()
     # sp.reserve()
     # Set a breakpoint here to keep page open

--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -11,6 +11,10 @@ import time
 import os
 import datetime as dt
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 LOGIN_URL = "https://reservenski.parkbrightonresort.com/login"
 
 
@@ -35,6 +39,10 @@ class BrightonParking:
         """Login the user with enviornment variables
         """
         # Get elements
+        WebDriverWait(self.driver, 15).until(EC.presence_of_all_elements_located(
+            (By.ID,
+             'emailAddress')
+        ))
         username = self.driver.find_element(By.ID, "emailAddress")
         password = self.driver.find_element(By.ID, "password")
         submit_btn = self.driver.find_element(
@@ -137,21 +145,26 @@ class BrightonParking:
         # Get the matching string
         date_string = f'{date:%A}, {date:%B} {date.day}'
 
-        # Find the date button
-        btn = self.driver.find_element(
+        # Find the date button. There are hidden calendar elements on the
+        # page (to support the animation of switching months), so some dates
+        # are duplicated. We find the first one that is enabled and click it.
+        btns = self.driver.find_elements(
             By.XPATH, '//div[@aria-label="{}"]'.format(date_string))
-        btn.click()
-
-        # Give it a moment to load the options
-        time.sleep(.5)
+        for btn in btns:
+            if btn.is_enabled() and btn.is_displayed():
+                btn.click()
+                break
 
     def select_parking_option(self):
         """Clicks the Season Pass Holder option once the date
         is selected, which redirect to purchasing
         """
-        # Find button
+        # Wait for button to load and click
+        btn_xpath = '//div[text()="Season\'s Pass"]/parent::*/parent::*'
+        WebDriverWait(self.driver, 3).until(EC.presence_of_element_located(
+            (By.XPATH, btn_xpath)))
         btn = self.driver.find_element(
-            By.XPATH, '//div[text()="Season\'s Pass"]/parent::*/parent::*')
+            By.XPATH, btn_xpath)
         btn.click()
 
         # Wait for honk to load
@@ -178,6 +191,8 @@ class BrightonParking:
         confirm_btn = self.driver.find_element(
             By.XPATH, '//button[text()="Confirm"]')
         confirm_btn.click()
+        # Give some time for the reservation to complete
+        time.sleep(3)
         print("Reservation complete")
 
     def output(self):
@@ -200,12 +215,15 @@ if __name__ == "__main__":
     options.add_argument("--disable-gpu")
     options.add_argument("--window-size=1280x1696")
     chrome = webdriver.Chrome(options=options)
-    sp = BrightonParking(chrome)
+    sp = BrightonParking(chrome, credentials={
+        "username": os.getenv("USERNAME"),
+        "password": os.getenv("PASSWORD")
+    })
     sp.start_session()
     sp.login()
     sp.activate_code()
     sp.go_to_selection_calendar()
-    sp.navigate_to_date(dt.datetime(2024, 1, 11))
+    sp.navigate_to_date(dt.datetime(2024, 1, 9))
     sp.select_parking_option()
     # sp.reserve()
     # Set a breakpoint here to keep page open

--- a/BrightonParking.py
+++ b/BrightonParking.py
@@ -21,7 +21,6 @@ class BrightonParking:
         self.username = credentials['username']
         self.password = credentials['password']
 
-
     def start_session(self):
         """Creates the selenium session
         """
@@ -61,7 +60,8 @@ class BrightonParking:
         this will give us the $0 option in booking
         """
         # Go to codes
-        self.driver.get("https://reservenski.parkbrightonresort.com/parking-codes")
+        self.driver.get(
+            "https://reservenski.parkbrightonresort.com/parking-codes")
 
         # Wait for button
         btn_xpath = '//button[text()="Reserve Parking"]'
@@ -213,4 +213,3 @@ if __name__ == "__main__":
     # sp.reserve()
     # Set a breakpoint here to keep page open
     print("Done")
-    

--- a/SolitudeParking.py
+++ b/SolitudeParking.py
@@ -21,7 +21,6 @@ class SolitudeParking:
         self.username = credentials['username']
         self.password = credentials['password']
 
-
     def start_session(self):
         """Creates the selenium session
         """
@@ -137,7 +136,7 @@ class SolitudeParking:
             date (datetime): date we want to select
         """
         # Get the matching string
-        date_string = date.strftime("%A, %B %d")
+        date_string = f'{date:%A}, {date:%B} {date.day}'
 
         # Find the date button
         btn = self.driver.find_element(
@@ -217,7 +216,7 @@ if __name__ == "__main__":
     # sp.go_to_selection_calendar()
     # sp.navigate_to_date(dt.datetime(2024, 2, 19))
     # sp.select_parking_option()
-    
+
 #     # sp.reserve()
 
 #     # just keep page open for debuggin

--- a/SolitudeParking.py
+++ b/SolitudeParking.py
@@ -157,7 +157,7 @@ class SolitudeParking:
         is selected, which redirect to purchasing
         """
         # Wait for button to load and click
-        btn_xpath = '//div[text()="Season\'s Pass"]/parent::*/parent::*'
+        btn_xpath = '//div[text()="Season Pass Holders"]/parent::*/parent::*'
         WebDriverWait(self.driver, 3).until(EC.presence_of_element_located(
             (By.XPATH, btn_xpath)))
         btn = self.driver.find_element(

--- a/SolitudeParking.py
+++ b/SolitudeParking.py
@@ -37,6 +37,10 @@ class SolitudeParking:
         """Login the user with enviornment variables
         """
         # Get elements
+        WebDriverWait(self.driver, 15).until(EC.presence_of_all_elements_located(
+            (By.ID,
+             'emailAddress')
+        ))
         username = self.driver.find_element(By.ID, "emailAddress")
         password = self.driver.find_element(By.ID, "password")
         submit_btn = self.driver.find_element(
@@ -138,21 +142,26 @@ class SolitudeParking:
         # Get the matching string
         date_string = f'{date:%A}, {date:%B} {date.day}'
 
-        # Find the date button
-        btn = self.driver.find_element(
+        # Find the date button. There are hidden calendar elements on the
+        # page (to support the animation of switching months), so some dates
+        # are duplicated. We find the first one that is enabled and click it.
+        btns = self.driver.find_elements(
             By.XPATH, '//div[@aria-label="{}"]'.format(date_string))
-        btn.click()
-
-        # Give it a moment to load the options
-        time.sleep(.5)
+        for btn in btns:
+            if btn.is_enabled() and btn.is_displayed():
+                btn.click()
+                break
 
     def select_parking_option(self):
         """Clicks the Season Pass Holder option once the date
         is selected, which redirect to purchasing
         """
-        # Find button
+        # Wait for button to load and click
+        btn_xpath = '//div[text()="Season\'s Pass"]/parent::*/parent::*'
+        WebDriverWait(self.driver, 3).until(EC.presence_of_element_located(
+            (By.XPATH, btn_xpath)))
         btn = self.driver.find_element(
-            By.XPATH, '//div[text()="Season Pass Holders"]/parent::*/parent::*')
+            By.XPATH, btn_xpath)
         btn.click()
 
         # Wait for honk to load
@@ -179,6 +188,8 @@ class SolitudeParking:
         confirm_btn = self.driver.find_element(
             By.XPATH, '//button[text()="Confirm"]')
         confirm_btn.click()
+        # Give some time for the reservation to complete
+        time.sleep(3)
         print("Reservation complete")
 
     def output(self):

--- a/check_any_lowered.py
+++ b/check_any_lowered.py
@@ -30,13 +30,6 @@ options.add_argument("--window-size=1280x1696")
 chrome = webdriver.Chrome(options=options)
 
 
-def getAvailabilities(apiClient: HonkApiClient, startDate: datetime.date, endDate: datetime.date) -> list[DateAvailability]:
-    global previousAvailabilities
-
-    currentAvailabilities = apiClient.getAvailability(startDate, endDate)
-    return currentAvailabilities
-
-
 def printNewOpenings(previousAvailabilities: list[DateAvailability], currentAvailabilities: list[DateAvailability], resortName: str):
     # Check to see if there are any dates with more available spots than before.
 
@@ -76,8 +69,8 @@ def checkBrighton():
     global brightonPrev
 
     client = HonkApiResortClients.BRIGHTON.value
-    currentAvailabilities = getAvailabilities(
-        client, datetime.date(2023, 12, 7), datetime.date(2024, 4, 10))
+    currentAvailabilities = client.getAvailability(
+        datetime.date(2023, 12, 7), datetime.date(2024, 4, 10))
     printNewOpenings(brightonPrev, currentAvailabilities, "Brighton")
     brightonPrev = currentAvailabilities
 
@@ -89,7 +82,7 @@ def checkSolitude():
     global solitudePrev
 
     client = HonkApiResortClients.SOLITUDE.value
-    currentAvailabilities = getAvailabilities(
+    currentAvailabilities = client.getAvailability(
         client, datetime.date(2023, 12, 7), datetime.date(2024, 4, 10))
     printNewOpenings(solitudePrev, currentAvailabilities, "Solitude")
     solitudePrev = currentAvailabilities

--- a/check_any_lowered.py
+++ b/check_any_lowered.py
@@ -1,0 +1,103 @@
+# one off script to check if parking availability has changed for any dates
+
+import datetime
+import os
+
+from selenium import webdriver
+
+
+from honkApi import DateAvailability, HonkApiClient, HonkApiResortClients
+
+import schedule
+import time
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# # Only set this to true at the beginning and if we try to make a reservation to
+# avoid spamming the API
+shouldUpdateCurrentReservations = True
+
+reservedDates = []
+
+
+options = webdriver.ChromeOptions()
+options.add_argument("--headless=new")
+options.add_argument('--no-sandbox')
+options.add_argument("--disable-gpu")
+options.add_argument("--window-size=1280x1696")
+chrome = webdriver.Chrome(options=options)
+
+
+def getAvailabilities(apiClient: HonkApiClient, startDate: datetime.date, endDate: datetime.date) -> list[DateAvailability]:
+    global previousAvailabilities
+
+    currentAvailabilities = apiClient.getAvailability(startDate, endDate)
+    return currentAvailabilities
+
+
+def printNewOpenings(previousAvailabilities: list[DateAvailability], currentAvailabilities: list[DateAvailability], resortName: str):
+    # Check to see if there are any dates with more available spots than before.
+
+    # Create a date -> availability map for previous availabilities
+    previousAvailabilitiesMap = {}
+    for availability in previousAvailabilities:
+        previousAvailabilitiesMap[availability.date] = availability
+
+    # Iterate through current availabilities and check if there are more spots
+    # available than before
+    for availability in currentAvailabilities:
+        if availability.date in previousAvailabilitiesMap:
+            previousAvailability = previousAvailabilitiesMap[availability.date]
+            if (
+                availability.seasonPassStatus.totalSpaces == previousAvailability.seasonPassStatus.totalSpaces
+                and availability.seasonPassStatus.occupiedSpaces < previousAvailability.seasonPassStatus.occupiedSpaces
+            ):
+                print(
+                    f"New spots found at {resortName} for date: {str(availability.date)}")
+                print("Previous availability: " + str(previousAvailability))
+                print("New availability: " + str(availability))
+
+
+brightonPrev = []
+
+
+def checkBrighton():
+    global brightonPrev
+
+    # Some printing to show that the script is running
+    print("b", end="", flush=True)
+
+    client = HonkApiResortClients.BRIGHTON.value
+    currentAvailabilities = getAvailabilities(
+        client, datetime.date(2023, 12, 7), datetime.date(2024, 4, 10))
+    printNewOpenings(brightonPrev, currentAvailabilities, "Brighton")
+    brightonPrev = currentAvailabilities
+
+
+solitudePrev = []
+
+
+def checkSolitude():
+    global solitudePrev
+
+    # Some printing to show that the script is running
+    print("s", end="", flush=True)
+
+    client = HonkApiResortClients.SOLITUDE.value
+    currentAvailabilities = getAvailabilities(
+        client, datetime.date(2023, 12, 7), datetime.date(2024, 4, 10))
+    printNewOpenings(solitudePrev, currentAvailabilities, "Solitude")
+    solitudePrev = currentAvailabilities
+
+
+if __name__ == "__main__":
+
+    schedule.every(30).seconds.do(checkBrighton)
+    schedule.every(30).seconds.do(checkSolitude)
+
+    # Loop until all dates are reserved
+    while True:
+        schedule.run_pending()
+        time.sleep(1)

--- a/check_any_lowered.py
+++ b/check_any_lowered.py
@@ -52,12 +52,19 @@ def printNewOpenings(previousAvailabilities: list[DateAvailability], currentAvai
             previousAvailability = previousAvailabilitiesMap[availability.date]
             if (
                 availability.seasonPassStatus.totalSpaces == previousAvailability.seasonPassStatus.totalSpaces
-                and availability.seasonPassStatus.occupiedSpaces < previousAvailability.seasonPassStatus.occupiedSpaces
+                and availability.seasonPassStatus.occupiedSpaces != previousAvailability.seasonPassStatus.occupiedSpaces
             ):
                 print(
-                    f"New spots found at {resortName} for date: {str(availability.date)}")
-                print("Previous availability: " + str(previousAvailability))
-                print("New availability: " + str(availability))
+                    f"Changes found at {resortName} for date: {str(availability.date)}")
+                print("\tPrevious availability: " +
+                      str(previousAvailability.seasonPassStatus))
+                print("\tNew availability: " +
+                      str(availability.seasonPassStatus))
+
+                if (availability.seasonPassStatus.occupiedSpaces < previousAvailability.seasonPassStatus.occupiedSpaces):
+                    print("~~~~~~~~And it was an increase!~~~~~~~~~~~")
+
+                print("")
 
 
 brightonPrev = []
@@ -96,6 +103,9 @@ if __name__ == "__main__":
 
     schedule.every(30).seconds.do(checkBrighton)
     schedule.every(30).seconds.do(checkSolitude)
+
+    checkBrighton()
+    checkSolitude()
 
     # Loop until all dates are reserved
     while True:

--- a/check_any_lowered.py
+++ b/check_any_lowered.py
@@ -51,9 +51,11 @@ def printNewOpenings(previousAvailabilities: list[DateAvailability], currentAvai
         if availability.date in previousAvailabilitiesMap:
             previousAvailability = previousAvailabilitiesMap[availability.date]
             if (
-                availability.seasonPassStatus.totalSpaces == previousAvailability.seasonPassStatus.totalSpaces
-                and availability.seasonPassStatus.occupiedSpaces != previousAvailability.seasonPassStatus.occupiedSpaces
+                availability.seasonPassStatus.totalSpaces != previousAvailability.seasonPassStatus.totalSpaces
+                or availability.seasonPassStatus.occupiedSpaces != previousAvailability.seasonPassStatus.occupiedSpaces
             ):
+                print("")
+                print(f"timestamp: {datetime.datetime.now()}")
                 print(
                     f"Changes found at {resortName} for date: {str(availability.date)}")
                 print("\tPrevious availability: " +

--- a/check_any_lowered.py
+++ b/check_any_lowered.py
@@ -75,9 +75,6 @@ brightonPrev = []
 def checkBrighton():
     global brightonPrev
 
-    # Some printing to show that the script is running
-    print("b", end="", flush=True)
-
     client = HonkApiResortClients.BRIGHTON.value
     currentAvailabilities = getAvailabilities(
         client, datetime.date(2023, 12, 7), datetime.date(2024, 4, 10))
@@ -91,9 +88,6 @@ solitudePrev = []
 def checkSolitude():
     global solitudePrev
 
-    # Some printing to show that the script is running
-    print("s", end="", flush=True)
-
     client = HonkApiResortClients.SOLITUDE.value
     currentAvailabilities = getAvailabilities(
         client, datetime.date(2023, 12, 7), datetime.date(2024, 4, 10))
@@ -102,6 +96,8 @@ def checkSolitude():
 
 
 if __name__ == "__main__":
+
+    print("checking for diffs at brighton and solitude")
 
     schedule.every(30).seconds.do(checkBrighton)
     schedule.every(30).seconds.do(checkSolitude)

--- a/honkApi.py
+++ b/honkApi.py
@@ -1,0 +1,211 @@
+import datetime
+from typing import Optional
+import requests
+import dataclasses
+
+
+# Returns a list of current reservations
+def getCurrentReservations(creds) -> list[datetime.date]:
+
+    try:
+        # Make the first fetch request
+        response = requests.post('https://platform.honkmobile.com/graphql?honkGUID=kznloxi05aiqtplsfw2kw', headers={
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
+            'Accept': '*/*',
+            'Accept-Language': 'en-US,en;q=0.5',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Referer': 'https://reservenski.parkbrightonresort.com/',
+            'content-type': 'application/json',
+            'x-authentication': '',
+            'Origin': 'https://reservenski.parkbrightonresort.com',
+            'Connection': 'keep-alive',
+            'Sec-Fetch-Dest': 'empty',
+            'Sec-Fetch-Mode': 'cors',
+            'Sec-Fetch-Site': 'cross-site',
+            'TE': 'trailers'
+        }, json={
+            'operationName': 'Login',
+            'variables': {
+                'input': {
+                    'emailAddress': creds["username"],
+                    'password': creds["password"],
+                }
+            },
+            'query': 'mutation Login($input: LoginInput!) {\n  login(input: $input) {\n    userSession {\n      oaTag\n      __typename\n    }\n    errors\n    __typename\n  }\n}\n'
+        })
+
+        response.raise_for_status()
+
+        data = response.json()
+        authString = data["data"]["login"]["userSession"]["oaTag"]
+
+        # Make another fetch request using the authString
+        reservationsResponse = requests.post('https://platform.honkmobile.com/graphql?honkGUID=kznloxi05aiqtplsfw2kw', headers={
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
+            'Accept': '*/*',
+            'Accept-Language': 'en-US,en;q=0.5',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Referer': 'https://reservenski.parkbrightonresort.com/',
+            'content-type': 'application/json',
+            'x-authentication': authString,
+            'Origin': 'https://reservenski.parkbrightonresort.com',
+            'Connection': 'keep-alive',
+            'Sec-Fetch-Dest': 'empty',
+            'Sec-Fetch-Mode': 'cors',
+            'Sec-Fetch-Site': 'cross-site',
+            'TE': 'trailers'
+        }, json={
+            'operationName': 'ZoneParkingSessions',
+            'variables': {
+                'zoneId': 'QPQdHW'
+            },
+            'query': 'query ZoneParkingSessions($zoneId: ID!) {\n  zoneParkingSessions(zoneId: $zoneId) {\n    hashid\n    rateName\n    startTime\n    endTime\n    voided\n    transactionHistory {\n      id\n      total\n      __typename\n    }\n    zone {\n      zoneId\n      hashid\n      address {\n        street\n        city\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n'
+        })
+
+        reservationsResponse.raise_for_status()
+
+        reservationsData = reservationsResponse.json()
+        rawReservations = reservationsData["data"]["zoneParkingSessions"]
+
+        # Parse the raw reservations into a list of dates, excluding voided reservations and reservations in the past
+        reservations = []
+        for reservation in rawReservations:
+            if reservation["voided"]:
+                continue
+            if datetime.datetime.strptime(reservation["endTime"], "%Y-%m-%dT%H:%M:%SZ") < datetime.datetime.now():
+                continue
+            reservations.append(datetime.datetime.strptime(
+                reservation["startTime"], "%Y-%m-%dT%H:%M:%SZ").date())
+        return reservations
+    except requests.exceptions.RequestException as error:
+        print("Error fetching reservations")
+        print(error)
+        raise error
+
+
+@dataclasses.dataclass
+class SpaceStatus:
+    occupiedSpaces: int
+    totalSpaces: int
+
+
+@dataclasses.dataclass
+class DateAvailability:
+    date: datetime.date
+    seasonPassStatus: SpaceStatus
+
+
+def parseSpaceStatus(rawSpaceStatus: Optional[dict]) -> SpaceStatus:
+    if (rawSpaceStatus is None):
+        return SpaceStatus(0, 0)
+
+    return SpaceStatus(
+        rawSpaceStatus["occupied_spaces"], rawSpaceStatus["total_spaces"]
+    )
+
+
+def getAvailability(startDate: datetime.date, endDate: datetime.date) -> list[DateAvailability]:
+
+    # Internal function to fetch availability for a given date range, used since the API can only fetch 1 calendar year at a time.
+    def _fetch(startDay: int, endDay: int, year: int) -> list[DateAvailability]:
+        url = 'https://platform.honkmobile.com/graphql?honkGUID=kznloxi05aiqtplsfw2kw'
+        headers = {
+            'Accept': '*/*',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Language': 'en-US,en;q=0.5',
+            'Connection': 'keep-alive',
+            'Origin': 'https://reservenski.parkbrightonresort.com',
+            'Referer': 'https://reservenski.parkbrightonresort.com/',
+            'Sec-Fetch-Dest': 'empty',
+            'Sec-Fetch-Mode': 'cors',
+            'Sec-Fetch-Site': 'cross-site',
+            'TE': 'trailers',
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0',
+            'content-type': 'application/json',
+            'x-authentication': '02eed7c6b23447188e5ab6bfd8831c9a'
+        }
+
+        requestData = {
+            'operationName': 'DetailedParkingAvailability',
+            'variables': {
+                'id': 'rrIb',
+                'startDay': startDay,
+                'endDay': endDay,
+                'year': year
+            },
+            'query': 'query DetailedParkingAvailability($id: ID!, $startDay: Int!, $endDay: Int!, $year: Int!) {\n  detailedParkingAvailability(\n    id: $id\n    startDay: $startDay\n    endDay: $endDay\n    year: $year\n  )\n}\n'
+        }
+
+        response = requests.post(url, headers=headers, json=requestData)
+        response.raise_for_status()
+        data = response.json()
+        rawAvailableDates = data["data"]["detailedParkingAvailability"]
+        # convert rawAvailableDates to a DateAvailability list; rawAvailableDates is a dict where each key is a date string
+        availableDates = []
+        for rawDate, rawAvailability in rawAvailableDates.items():
+            seasonPassString = "jZ3W0cN"
+
+            parsedDate = datetime.datetime.strptime(
+                rawDate, "%Y-%m-%dT%H:%M:%S%z").date()
+            seasonPass = parseSpaceStatus(
+                rawAvailability.get(seasonPassString))
+            availableDates.append(DateAvailability(
+                date=parsedDate,
+                seasonPassStatus=seasonPass)
+            )
+        return availableDates
+
+    # Chunk the date range into a dict of year -> startDay, endDay
+    def daterange(startDate, emdDate):
+        for n in range(int((emdDate - startDate).days)):
+            yield startDate + datetime.timedelta(n)
+    dateRange = {}
+    for date in daterange(startDate, endDate + datetime.timedelta(days=1)):
+        if date.year not in dateRange:
+            dateRange[date.year] = {"startDay": date.timetuple(
+            ).tm_yday, "endDay": date.timetuple().tm_yday}
+        else:
+            dateRange[date.year]["endDay"] = date.timetuple().tm_yday
+
+    # Fetch availability for each year
+    availability = []
+    for year, dateRange in dateRange.items():
+        availability += _fetch(dateRange["startDay"],
+                               dateRange["endDay"], year)
+    return availability
+
+
+# Given a list of dates, returns those that are available to book
+def getAvailableDates(requestedDates: list[datetime.date]) -> list[datetime.date]:
+    if len(requestedDates) == 0:
+        return []
+
+    minDate = min(requestedDates)
+    maxDate = max(requestedDates)
+    availability = getAvailability(minDate, maxDate)
+    availableDates = []
+
+    # Make a date: availability dict
+    availabilityDict = {}
+    for dateAvailability in availability:
+        availabilityDict[dateAvailability.date] = dateAvailability.seasonPassStatus
+
+    for date in requestedDates:
+        if date in availabilityDict and availabilityDict[date].occupiedSpaces < availabilityDict[date].totalSpaces:
+            availableDates.append(date)
+    return availableDates
+
+
+if __name__ == "__main__":
+    # reservations = getCurrentReservations()
+    # print(reservations)
+
+    # dateAvailabilities = getAvailability(datetime.date.today(), datetime.date.today() + datetime.timedelta(days=50))
+    # for dateAvailability in dateAvailabilities:
+    #     print(dateAvailability)
+
+    requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
+    availableDates = getAvailableDates(requestedDates)
+    print(availableDates)
+
+    print("done")

--- a/honkApi.py
+++ b/honkApi.py
@@ -1,86 +1,14 @@
 import datetime
+import os
 from typing import Optional
 import requests
 import dataclasses
+from enum import Enum
 
 
-# Returns a list of current reservations
-def getCurrentReservations(creds) -> list[datetime.date]:
+from dotenv import load_dotenv
 
-    try:
-        # Make the first fetch request
-        response = requests.post('https://platform.honkmobile.com/graphql?honkGUID=kznloxi05aiqtplsfw2kw', headers={
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
-            'Accept': '*/*',
-            'Accept-Language': 'en-US,en;q=0.5',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://reservenski.parkbrightonresort.com/',
-            'content-type': 'application/json',
-            'x-authentication': '',
-            'Origin': 'https://reservenski.parkbrightonresort.com',
-            'Connection': 'keep-alive',
-            'Sec-Fetch-Dest': 'empty',
-            'Sec-Fetch-Mode': 'cors',
-            'Sec-Fetch-Site': 'cross-site',
-            'TE': 'trailers'
-        }, json={
-            'operationName': 'Login',
-            'variables': {
-                'input': {
-                    'emailAddress': creds["username"],
-                    'password': creds["password"],
-                }
-            },
-            'query': 'mutation Login($input: LoginInput!) {\n  login(input: $input) {\n    userSession {\n      oaTag\n      __typename\n    }\n    errors\n    __typename\n  }\n}\n'
-        })
-
-        response.raise_for_status()
-
-        data = response.json()
-        authString = data["data"]["login"]["userSession"]["oaTag"]
-
-        # Make another fetch request using the authString
-        reservationsResponse = requests.post('https://platform.honkmobile.com/graphql?honkGUID=kznloxi05aiqtplsfw2kw', headers={
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
-            'Accept': '*/*',
-            'Accept-Language': 'en-US,en;q=0.5',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://reservenski.parkbrightonresort.com/',
-            'content-type': 'application/json',
-            'x-authentication': authString,
-            'Origin': 'https://reservenski.parkbrightonresort.com',
-            'Connection': 'keep-alive',
-            'Sec-Fetch-Dest': 'empty',
-            'Sec-Fetch-Mode': 'cors',
-            'Sec-Fetch-Site': 'cross-site',
-            'TE': 'trailers'
-        }, json={
-            'operationName': 'ZoneParkingSessions',
-            'variables': {
-                'zoneId': 'QPQdHW'
-            },
-            'query': 'query ZoneParkingSessions($zoneId: ID!) {\n  zoneParkingSessions(zoneId: $zoneId) {\n    hashid\n    rateName\n    startTime\n    endTime\n    voided\n    transactionHistory {\n      id\n      total\n      __typename\n    }\n    zone {\n      zoneId\n      hashid\n      address {\n        street\n        city\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n'
-        })
-
-        reservationsResponse.raise_for_status()
-
-        reservationsData = reservationsResponse.json()
-        rawReservations = reservationsData["data"]["zoneParkingSessions"]
-
-        # Parse the raw reservations into a list of dates, excluding voided reservations and reservations in the past
-        reservations = []
-        for reservation in rawReservations:
-            if reservation["voided"]:
-                continue
-            if datetime.datetime.strptime(reservation["endTime"], "%Y-%m-%dT%H:%M:%SZ") < datetime.datetime.now():
-                continue
-            reservations.append(datetime.datetime.strptime(
-                reservation["startTime"], "%Y-%m-%dT%H:%M:%SZ").date())
-        return reservations
-    except requests.exceptions.RequestException as error:
-        print("Error fetching reservations")
-        print(error)
-        raise error
+load_dotenv()
 
 
 @dataclasses.dataclass
@@ -95,120 +23,227 @@ class DateAvailability:
     seasonPassStatus: SpaceStatus
 
 
-def parseSpaceStatus(rawSpaceStatus: Optional[dict]) -> SpaceStatus:
-    if (rawSpaceStatus is None):
-        return SpaceStatus(0, 0)
+class HonkApiClient:
+    def __init__(self, honkGUID, zoneId, resortId, resortName):
+        self.honkGUID = honkGUID
+        self.zoneId = zoneId
+        self.resortId = resortId
+        self.resortName = resortName
 
-    return SpaceStatus(
-        rawSpaceStatus["occupied_spaces"], rawSpaceStatus["total_spaces"]
-    )
+    def addCredentials(self, creds):
+        self.creds = creds
 
+    # Returns a list of current reservations
 
-def getAvailability(startDate: datetime.date, endDate: datetime.date) -> list[DateAvailability]:
+    def getCurrentReservations(self) -> list[datetime.date]:
 
-    # Internal function to fetch availability for a given date range, used since the API can only fetch 1 calendar year at a time.
-    def _fetch(startDay: int, endDay: int, year: int) -> list[DateAvailability]:
         try:
-            url = 'https://platform.honkmobile.com/graphql?honkGUID=kznloxi05aiqtplsfw2kw'
-            headers = {
+            # Make the first fetch request
+            response = requests.post(f'https://platform.honkmobile.com/graphql?honkGUID={self.honkGUID}', headers={
+                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
                 'Accept': '*/*',
-                'Accept-Encoding': 'gzip, deflate, br',
                 'Accept-Language': 'en-US,en;q=0.5',
-                'Connection': 'keep-alive',
-                'Origin': 'https://reservenski.parkbrightonresort.com',
+                'Accept-Encoding': 'gzip, deflate, br',
                 'Referer': 'https://reservenski.parkbrightonresort.com/',
+                'content-type': 'application/json',
+                'x-authentication': '',
+                'Origin': 'https://reservenski.parkbrightonresort.com',
+                'Connection': 'keep-alive',
                 'Sec-Fetch-Dest': 'empty',
                 'Sec-Fetch-Mode': 'cors',
                 'Sec-Fetch-Site': 'cross-site',
-                'TE': 'trailers',
-                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0',
-                'content-type': 'application/json',
-                'x-authentication': '02eed7c6b23447188e5ab6bfd8831c9a'
-            }
-
-            requestData = {
-                'operationName': 'DetailedParkingAvailability',
+                'TE': 'trailers'
+            }, json={
+                'operationName': 'Login',
                 'variables': {
-                    'id': 'rrIb',
-                    'startDay': startDay,
-                    'endDay': endDay,
-                    'year': year
+                    'input': {
+                        'emailAddress': self.creds["username"],
+                        'password': self.creds["password"]
+                    }
                 },
-                'query': 'query DetailedParkingAvailability($id: ID!, $startDay: Int!, $endDay: Int!, $year: Int!) {\n  detailedParkingAvailability(\n    id: $id\n    startDay: $startDay\n    endDay: $endDay\n    year: $year\n  )\n}\n'
-            }
+                'query': 'mutation Login($input: LoginInput!) {\n  login(input: $input) {\n    userSession {\n      oaTag\n      __typename\n    }\n    errors\n    __typename\n  }\n}\n'
+            })
 
-            response = requests.post(url, headers=headers, json=requestData)
             response.raise_for_status()
+
             data = response.json()
-            rawAvailableDates = data["data"]["detailedParkingAvailability"]
-            # convert rawAvailableDates to a DateAvailability list; rawAvailableDates is a dict where each key is a date string
-            availableDates = []
-            for rawDate, rawAvailability in rawAvailableDates.items():
-                seasonPassString = "jZ3W0cN"
+            authString = data["data"]["login"]["userSession"]["oaTag"]
 
-                parsedDate = datetime.datetime.strptime(
-                    rawDate, "%Y-%m-%dT%H:%M:%S%z").date()
+            # Make another fetch request using the authString
+            reservationsResponse = requests.post(f'https://platform.honkmobile.com/graphql?honkGUID={self.honkGUID}', headers={
+                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
+                'Accept': '*/*',
+                'Accept-Language': 'en-US,en;q=0.5',
+                'Accept-Encoding': 'gzip, deflate, br',
+                'Referer': 'https://reservenski.parkbrightonresort.com/',
+                'content-type': 'application/json',
+                'x-authentication': authString,
+                'Origin': 'https://reservenski.parkbrightonresort.com',
+                'Connection': 'keep-alive',
+                'Sec-Fetch-Dest': 'empty',
+                'Sec-Fetch-Mode': 'cors',
+                'Sec-Fetch-Site': 'cross-site',
+                'TE': 'trailers'
+            }, json={
+                'operationName': 'ZoneParkingSessions',
+                'variables': {
+                    'zoneId': self.zoneId
+                },
+                'query': 'query ZoneParkingSessions($zoneId: ID!) {\n  zoneParkingSessions(zoneId: $zoneId) {\n    hashid\n    rateName\n    startTime\n    endTime\n    voided\n    transactionHistory {\n      id\n      total\n      __typename\n    }\n    zone {\n      zoneId\n      hashid\n      address {\n        street\n        city\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n'
+            })
 
-                # Here's something fun: it seems like when the API doesn't show an availibility for a certain type, it falls back to the "general" type.
-                # This might imply that at some point, Brighton decides that Season Pass availability is in the same pool as general availability?
-                # AKA for spots released early, it's split into groups of season pass and general, but for spots released later, it's just one big pool?
-                if seasonPassString not in rawAvailability:
-                    parkingTypeKey = "general"
-                else:
-                    parkingTypeKey = seasonPassString
+            reservationsResponse.raise_for_status()
 
-                seasonPass = parseSpaceStatus(
-                    rawAvailability.get(parkingTypeKey))
-                availableDates.append(DateAvailability(
-                    date=parsedDate,
-                    seasonPassStatus=seasonPass)
-                )
-            return availableDates
+            reservationsData = reservationsResponse.json()
+            rawReservations = reservationsData["data"]["zoneParkingSessions"]
+
+            # Parse the raw reservations into a list of dates, excluding voided reservations and reservations in the past
+            reservations = []
+            for reservation in rawReservations:
+                if reservation["voided"]:
+                    continue
+                if datetime.datetime.strptime(reservation["endTime"], "%Y-%m-%dT%H:%M:%SZ") < datetime.datetime.now():
+                    continue
+                reservations.append(datetime.datetime.strptime(
+                    reservation["startTime"], "%Y-%m-%dT%H:%M:%SZ").date())
+            return reservations
         except requests.exceptions.RequestException as error:
-            print("Error fetching availability")
+            print("Error fetching reservations")
             print(error)
+            raise error
+
+    def getAvailability(self, startDate: datetime.date, endDate: datetime.date) -> list[DateAvailability]:
+
+        # Internal function to parse the raw space status dict into a SpaceStatus object
+        def parseSpaceStatus(rawSpaceStatus: Optional[dict]) -> SpaceStatus:
+            if (rawSpaceStatus is None):
+                return SpaceStatus(0, 0)
+
+            return SpaceStatus(
+                rawSpaceStatus["occupied_spaces"], rawSpaceStatus["total_spaces"]
+            )
+
+        # Internal function to fetch availability for a given date range, used since the API can only fetch 1 calendar year at a time.
+        def _fetch(startDay: int, endDay: int, year: int) -> list[DateAvailability]:
+            try:
+                url = f'https://platform.honkmobile.com/graphql?honkGUID={self.honkGUID}'
+                headers = {
+                    'Accept': '*/*',
+                    'Accept-Encoding': 'gzip, deflate, br',
+                    'Accept-Language': 'en-US,en;q=0.5',
+                    'Connection': 'keep-alive',
+                    'Origin': 'https://reservenski.parkbrightonresort.com',
+                    'Referer': 'https://reservenski.parkbrightonresort.com/',
+                    'Sec-Fetch-Dest': 'empty',
+                    'Sec-Fetch-Mode': 'cors',
+                    'Sec-Fetch-Site': 'cross-site',
+                    'TE': 'trailers',
+                    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0',
+                    'content-type': 'application/json',
+                    'x-authentication': '02eed7c6b23447188e5ab6bfd8831c9a'
+                }
+
+                requestData = {
+                    'operationName': 'DetailedParkingAvailability',
+                    'variables': {
+                        'id': self.resortId,
+                        'startDay': startDay,
+                        'endDay': endDay,
+                        'year': year
+                    },
+                    'query': 'query DetailedParkingAvailability($id: ID!, $startDay: Int!, $endDay: Int!, $year: Int!) {\n  detailedParkingAvailability(\n    id: $id\n    startDay: $startDay\n    endDay: $endDay\n    year: $year\n  )\n}\n'
+                }
+
+                response = requests.post(
+                    url, headers=headers, json=requestData)
+                response.raise_for_status()
+                data = response.json()
+                rawAvailableDates = data["data"]["detailedParkingAvailability"]
+                # convert rawAvailableDates to a DateAvailability list; rawAvailableDates is a dict where each key is a date string
+                availableDates = []
+                for rawDate, rawAvailability in rawAvailableDates.items():
+                    seasonPassString = "jZ3W0cN"
+
+                    parsedDate = datetime.datetime.strptime(
+                        rawDate, "%Y-%m-%dT%H:%M:%S%z").date()
+
+                    # Here's something fun: it seems like when the API doesn't show an availibility for a certain type, it falls back to the "general" type.
+                    # This might imply that at some point, Brighton decides that Season Pass availability is in the same pool as general availability?
+                    # AKA for spots released early, it's split into groups of season pass and general, but for spots released later, it's just one big pool?
+                    if seasonPassString not in rawAvailability:
+                        parkingTypeKey = "general"
+                    else:
+                        parkingTypeKey = seasonPassString
+
+                    seasonPass = parseSpaceStatus(
+                        rawAvailability.get(parkingTypeKey))
+                    availableDates.append(DateAvailability(
+                        date=parsedDate,
+                        seasonPassStatus=seasonPass)
+                    )
+                return availableDates
+            except requests.exceptions.RequestException as error:
+                print("Error fetching availability")
+                print(error)
+                return []
+
+        # Chunk the date range into a dict of year -> startDay, endDay
+        def daterange(startDate, emdDate):
+            for n in range(int((emdDate - startDate).days)):
+                yield startDate + datetime.timedelta(n)
+        dateRange = {}
+        for date in daterange(startDate, endDate + datetime.timedelta(days=1)):
+            if date.year not in dateRange:
+                dateRange[date.year] = {"startDay": date.timetuple(
+                ).tm_yday, "endDay": date.timetuple().tm_yday}
+            else:
+                dateRange[date.year]["endDay"] = date.timetuple().tm_yday
+
+        # Fetch availability for each year
+        availability = []
+        for year, dateRange in dateRange.items():
+            availability += _fetch(dateRange["startDay"],
+                                   dateRange["endDay"], year)
+        return availability
+
+    # Given a list of dates, returns those that are available to book
+    def getAvailableDates(self, requestedDates: list[datetime.date]) -> list[datetime.date]:
+        if len(requestedDates) == 0:
             return []
 
-    # Chunk the date range into a dict of year -> startDay, endDay
+        minDate = min(requestedDates)
+        maxDate = max(requestedDates)
+        availability = self.getAvailability(minDate, maxDate)
+        availableDates = []
 
-    def daterange(startDate, emdDate):
-        for n in range(int((emdDate - startDate).days)):
-            yield startDate + datetime.timedelta(n)
-    dateRange = {}
-    for date in daterange(startDate, endDate + datetime.timedelta(days=1)):
-        if date.year not in dateRange:
-            dateRange[date.year] = {"startDay": date.timetuple(
-            ).tm_yday, "endDay": date.timetuple().tm_yday}
-        else:
-            dateRange[date.year]["endDay"] = date.timetuple().tm_yday
+        # Make a date: availability dict
+        availabilityDict = {}
+        for dateAvailability in availability:
+            availabilityDict[dateAvailability.date] = dateAvailability.seasonPassStatus
 
-    # Fetch availability for each year
-    availability = []
-    for year, dateRange in dateRange.items():
-        availability += _fetch(dateRange["startDay"],
-                               dateRange["endDay"], year)
-    return availability
+        for date in requestedDates:
+            if date in availabilityDict and availabilityDict[date].occupiedSpaces < availabilityDict[date].totalSpaces:
+                availableDates.append(date)
+        return availableDates
 
 
-# Given a list of dates, returns those that are available to book
-def getAvailableDates(requestedDates: list[datetime.date]) -> list[datetime.date]:
-    if len(requestedDates) == 0:
-        return []
-
-    minDate = min(requestedDates)
-    maxDate = max(requestedDates)
-    availability = getAvailability(minDate, maxDate)
-    availableDates = []
-
-    # Make a date: availability dict
-    availabilityDict = {}
-    for dateAvailability in availability:
-        availabilityDict[dateAvailability.date] = dateAvailability.seasonPassStatus
-
-    for date in requestedDates:
-        if date in availabilityDict and availabilityDict[date].occupiedSpaces < availabilityDict[date].totalSpaces:
-            availableDates.append(date)
-    return availableDates
+# example use:
+# client = HonkApiResortClients.BRIGHTON.value
+# client.addCredentials({username: "username", password: "password"})
+# reservations = client.getCurrentReservations()
+class HonkApiResortClients(Enum):
+    BRIGHTON = HonkApiClient(
+        honkGUID="kznloxi05aiqtplsfw2kw",
+        zoneId="QPQdHW",
+        resortId="rrIb",
+        resortName="Brighton",
+    )
+    SOLITUDE = HonkApiClient(
+        honkGUID="247dj8tezair8h6n5ru7pq",
+        zoneId="9rwDuX",
+        resortId="n6iK",
+        resortName="Solitude",
+    )
 
 
 if __name__ == "__main__":
@@ -219,8 +254,15 @@ if __name__ == "__main__":
     # for dateAvailability in dateAvailabilities:
     #     print(dateAvailability)
 
-    requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
-    availableDates = getAvailableDates(requestedDates)
+    client = HonkApiResortClients.SOLITUDE.value
+    client.addCredentials({
+        "username": os.getenv("USERNAME"),
+        "password": os.getenv("PASSWORD")
+    })
+
+    requestedDates = [datetime.date(2023, 12, 8), datetime.date(
+        2023, 12, 10), datetime.date(2024, 2, 8)]
+    availableDates = client.getAvailableDates(requestedDates)
     print(availableDates)
 
     print("done")

--- a/honkApi.py
+++ b/honkApi.py
@@ -34,25 +34,12 @@ class HonkApiClient:
         self.creds = creds
 
     # Returns a list of current reservations
-
     def getCurrentReservations(self) -> list[datetime.date]:
 
         try:
             # Make the first fetch request
             response = requests.post(f'https://platform.honkmobile.com/graphql?honkGUID={self.honkGUID}', headers={
-                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
-                'Accept': '*/*',
-                'Accept-Language': 'en-US,en;q=0.5',
-                'Accept-Encoding': 'gzip, deflate, br',
-                'Referer': 'https://reservenski.parkbrightonresort.com/',
                 'content-type': 'application/json',
-                'x-authentication': '',
-                'Origin': 'https://reservenski.parkbrightonresort.com',
-                'Connection': 'keep-alive',
-                'Sec-Fetch-Dest': 'empty',
-                'Sec-Fetch-Mode': 'cors',
-                'Sec-Fetch-Site': 'cross-site',
-                'TE': 'trailers'
             }, json={
                 'operationName': 'Login',
                 'variables': {
@@ -71,19 +58,8 @@ class HonkApiClient:
 
             # Make another fetch request using the authString
             reservationsResponse = requests.post(f'https://platform.honkmobile.com/graphql?honkGUID={self.honkGUID}', headers={
-                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
-                'Accept': '*/*',
-                'Accept-Language': 'en-US,en;q=0.5',
-                'Accept-Encoding': 'gzip, deflate, br',
-                'Referer': 'https://reservenski.parkbrightonresort.com/',
                 'content-type': 'application/json',
                 'x-authentication': authString,
-                'Origin': 'https://reservenski.parkbrightonresort.com',
-                'Connection': 'keep-alive',
-                'Sec-Fetch-Dest': 'empty',
-                'Sec-Fetch-Mode': 'cors',
-                'Sec-Fetch-Site': 'cross-site',
-                'TE': 'trailers'
             }, json={
                 'operationName': 'ZoneParkingSessions',
                 'variables': {
@@ -128,19 +104,7 @@ class HonkApiClient:
             try:
                 url = f'https://platform.honkmobile.com/graphql?honkGUID={self.honkGUID}'
                 headers = {
-                    'Accept': '*/*',
-                    'Accept-Encoding': 'gzip, deflate, br',
-                    'Accept-Language': 'en-US,en;q=0.5',
-                    'Connection': 'keep-alive',
-                    'Origin': 'https://reservenski.parkbrightonresort.com',
-                    'Referer': 'https://reservenski.parkbrightonresort.com/',
-                    'Sec-Fetch-Dest': 'empty',
-                    'Sec-Fetch-Mode': 'cors',
-                    'Sec-Fetch-Site': 'cross-site',
-                    'TE': 'trailers',
-                    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0',
                     'content-type': 'application/json',
-                    'x-authentication': '02eed7c6b23447188e5ab6bfd8831c9a'
                 }
 
                 requestData = {

--- a/honkApi.py
+++ b/honkApi.py
@@ -147,8 +147,17 @@ def getAvailability(startDate: datetime.date, endDate: datetime.date) -> list[Da
 
             parsedDate = datetime.datetime.strptime(
                 rawDate, "%Y-%m-%dT%H:%M:%S%z").date()
+
+            # Here's something fun: it seems like when the API doesn't show an availibility for a certain type, it falls back to the "general" type.
+            # This might imply that at some point, Brighton decides that Season Pass availability is in the same pool as general availability?
+            # AKA for spots released early, it's split into groups of season pass and general, but for spots released later, it's just one big pool?
+            if seasonPassString not in rawAvailability:
+                parkingTypeKey = "general"
+            else:
+                parkingTypeKey = seasonPassString
+
             seasonPass = parseSpaceStatus(
-                rawAvailability.get(seasonPassString))
+                rawAvailability.get(parkingTypeKey))
             availableDates.append(DateAvailability(
                 date=parsedDate,
                 seasonPassStatus=seasonPass)

--- a/pollingRunner.py
+++ b/pollingRunner.py
@@ -14,8 +14,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+requestedDates = [datetime.date(2023, 12, 8)]
 # requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
-requestedDates = [datetime.date(2024, 1, 9)]
+# requestedDates = [datetime.date(2024, 1, 9)]
 
 # # Only set this to true at the beginning and if we try to make a reservation to
 # avoid spamming the API

--- a/pollingRunner.py
+++ b/pollingRunner.py
@@ -1,0 +1,86 @@
+import datetime
+
+from selenium import webdriver
+
+
+from honkApi import getCurrentReservations, getAvailableDates
+
+from BrightonParking import BrightonParking
+import schedule
+import time
+
+user = {
+    "username": "edwardhcai@gmail.com",
+    "password": "8cb!9Qh.tk"
+}
+
+# requestedDates = [datetime.date(2024, 1, 18), datetime.date(2023, 12, 9)]
+requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
+# requestedDates = [datetime.date(2023, 12, 9)]
+
+
+# # Only set this to true at the beginning and if we try to make a reservation to
+# avoid spamming the API
+shouldUpdateCurrentReservations = True
+
+reservedDates = []
+
+
+options = webdriver.ChromeOptions()
+options.add_argument("--headless=new")
+options.add_argument('--no-sandbox')
+options.add_argument("--disable-gpu")
+options.add_argument("--window-size=1280x1696")
+chrome = webdriver.Chrome(options=options)
+
+
+def checkForReservations():
+    global shouldUpdateCurrentReservations
+    global reservedDates
+
+    if shouldUpdateCurrentReservations:
+        reservedDates = getCurrentReservations(creds=user)
+        print("Updated current reservations", reservedDates)
+        shouldUpdateCurrentReservations = False
+
+    # Check dates in requestedDates but not in reservedDates
+    datesToCheck = [
+        date for date in requestedDates if date not in reservedDates]
+
+    availableDates = getAvailableDates(datesToCheck)
+
+    # Some printing to show that the script is running
+    if (len(availableDates) == 0):
+        print(".", end="", flush=True)
+        return
+
+    for date in availableDates:
+        print("Attempting to reserve date: " + str(date))
+        bp = BrightonParking(driver=chrome, credentials=user)
+        try:
+            bp.make_reservation(datetime.datetime(
+                date.year, date.month, date.day))
+            shouldUpdateCurrentReservations = True
+        except Exception as e:
+            print("Failed to reserve date: " + str(date))
+            print(e)
+
+
+if __name__ == "__main__":
+
+    print("Attempting to reserve dates: " + str(requestedDates))
+
+    schedule.every(30).seconds.do(checkForReservations)
+
+    # Loop until all dates are reserved
+    while True:
+        if all(date in reservedDates for date in requestedDates):
+            print("All dates reserved!")
+            exit(0)
+
+        if len(reservedDates) >= 5:
+            print("Reached max reservations")
+            exit(0)
+
+        schedule.run_pending()
+        time.sleep(1)

--- a/pollingRunner.py
+++ b/pollingRunner.py
@@ -14,7 +14,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
+# requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
+requestedDates = [datetime.date(2024, 1, 9)]
 
 # # Only set this to true at the beginning and if we try to make a reservation to
 # avoid spamming the API
@@ -72,6 +73,7 @@ def checkForReservations():
 if __name__ == "__main__":
     print("Script running to reserve dates: " + str(requestedDates))
 
+    checkForReservations()
     schedule.every(10).seconds.do(checkForReservations)
 
     # Loop until all dates are reserved

--- a/pollingRunner.py
+++ b/pollingRunner.py
@@ -1,7 +1,26 @@
+"""
+Use: python pollingRunner.py --config <configFile>
+defaults to pollingConfig.json
+
+Example config file:
+{
+    "resort": "solitude",
+    "username": "johndeervalley@gmail.com",
+    "password": "snowboarderssuck",
+    "dates": [
+        "2023-12-25",
+        "2024-01-05",
+    ]
+}
+"""
+
 import datetime
-import os
+import json
+
+from argparse import ArgumentParser
 
 from selenium import webdriver
+from SolitudeParking import SolitudeParking
 
 
 from honkApi import HonkApiResortClients
@@ -9,21 +28,6 @@ from honkApi import HonkApiResortClients
 from BrightonParking import BrightonParking
 import schedule
 import time
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-
-requestedDates = [datetime.date(2023, 12, 8)]
-# requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
-# requestedDates = [datetime.date(2024, 1, 9)]
-
-# # Only set this to true at the beginning and if we try to make a reservation to
-# avoid spamming the API
-shouldUpdateCurrentReservations = True
-
-reservedDates = []
 
 
 options = webdriver.ChromeOptions()
@@ -33,11 +37,14 @@ options.add_argument("--disable-gpu")
 options.add_argument("--window-size=1280x1696")
 chrome = webdriver.Chrome(options=options)
 
-apiClient = HonkApiResortClients.BRIGHTON.value
-apiClient.addCredentials({
-    "username": os.getenv("USERNAME"),
-    "password": os.getenv("PASSWORD")
-})
+
+# Only set this to true at the beginning and if we try to make a reservation to
+# avoid spamming the API
+shouldUpdateCurrentReservations = True
+
+# Keep track of the reservations the account currently has; used to
+# avoid attempting to reserve a date that we already have reserved
+reservedDates = []
 
 
 def checkForReservations():
@@ -49,10 +56,11 @@ def checkForReservations():
         print("Updated current reservations", reservedDates)
         shouldUpdateCurrentReservations = False
 
-    # Check dates in requestedDates but not in reservedDates
+    # Try to reserve requested dates that are:
+    #   - not already reserved
+    #   - available
     datesToCheck = [
         date for date in requestedDates if date not in reservedDates]
-
     availableDates = apiClient.getAvailableDates(datesToCheck)
 
     # Some printing to show that the script is running
@@ -62,23 +70,63 @@ def checkForReservations():
 
     for date in availableDates:
         print("Attempting to reserve date: " + str(date))
-        bp = BrightonParking(driver=chrome, credentials=apiClient.creds)
         try:
-            bp.make_reservation(datetime.datetime(
-                date.year, date.month, date.day))
             shouldUpdateCurrentReservations = True
+            webDriver.make_reservation(datetime.datetime(
+                date.year, date.month, date.day))
         except Exception as e:
             print("Failed to reserve date: " + str(date))
             print(e)
 
 
 if __name__ == "__main__":
-    print("Script running to reserve dates: " + str(requestedDates))
+    # Read in command line argument --config, specifying the file to read.
+    # Defaults to pollingConfig.json
+    parser = ArgumentParser()
+    parser.add_argument("--config", default="pollingConfig.json")
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        config = json.load(f)
+
+    try:
+        creds = {
+            "username": config["username"],
+            "password": config["password"]
+        }
+
+        if config["resort"] == "brighton":
+            apiClient = HonkApiResortClients.BRIGHTON.value
+            webDriver = BrightonParking(
+                driver=chrome, credentials=creds)
+        elif config["resort"] == "solitude":
+            apiClient = HonkApiResortClients.SOLITUDE.value
+            webDriver = SolitudeParking(
+                driver=chrome, credentials=creds)
+        else:
+            raise Exception(
+                "Invalid resort specified in config, must be 'brighton' or 'solitude'")
+
+        apiClient.addCredentials(creds)
+
+        requestedDates: list[datetime.date] = [datetime.datetime.strptime(
+            date, "%Y-%m-%d").date() for date in config["dates"]
+        ]
+
+    except Exception as e:
+        print("Invalid config file: ", e)
+
+    print("Script config")
+    print("\tResort: " + apiClient.resortName)
+    print("\tTarget Dates: " +
+          ', '.join([date.strftime('%Y-%m-%d') for date in requestedDates])
+          )
+    print("\tUsername: " + apiClient.creds["username"])
 
     checkForReservations()
     schedule.every(10).seconds.do(checkForReservations)
 
-    # Loop until all dates are reserved
+    # Loop until all dates are reserved, or we reach max reservations
     while True:
         if all(date in reservedDates for date in requestedDates):
             print("All dates reserved!")

--- a/pollingRunner.py
+++ b/pollingRunner.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 
 from selenium import webdriver
 
@@ -9,15 +10,16 @@ from BrightonParking import BrightonParking
 import schedule
 import time
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 user = {
-    "username": "edwardhcai@gmail.com",
-    "password": "8cb!9Qh.tk"
+    "username": os.getenv("USERNAME"),
+    "password": os.getenv("PASSWORD")
 }
 
-# requestedDates = [datetime.date(2024, 1, 18), datetime.date(2023, 12, 9)]
 requestedDates = [datetime.date(2023, 12, 8), datetime.date(2023, 12, 10)]
-# requestedDates = [datetime.date(2023, 12, 9)]
-
 
 # # Only set this to true at the beginning and if we try to make a reservation to
 # avoid spamming the API
@@ -68,9 +70,9 @@ def checkForReservations():
 
 if __name__ == "__main__":
 
-    print("Attempting to reserve dates: " + str(requestedDates))
+    print("Script running to reserve dates: " + str(requestedDates))
 
-    schedule.every(30).seconds.do(checkForReservations)
+    schedule.every(10).seconds.do(checkForReservations)
 
     # Loop until all dates are reserved
     while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ h11==0.14.0
 idna==3.4
 outcome==1.3.0.post0
 PySocks==1.7.1
+python-dotenv==1.0.0
 requests==2.31.0
+schedule==1.2.1
 selenium==4.15.2
 sniffio==1.3.0
 sortedcontainers==2.4.0


### PR DESCRIPTION
Adds the pollingRunner.py and check_any_lowered.py scripts (wtf am I doing, I added so much camel case stuff before realizing)

pollingRunner.py 
- loads USERNAME and PASSWORD from env (I added dotenv, so I'm currently keeping those in a .env file)
- has a `requestedDates` global var to determine which dates it should try to reserve
- polls to see if any of those dates are available once per 10 seconds; if so, tries to reserve

check_any_lowered.py
- prints out any changes to parking availability for both Brighton and Solitude

pollingRunner is obviously not super cleaned up, though it should be super easy to make it work for Solitude (you can look at check_any_lowered for examples of using both Brighton and Solitude honk api clients)